### PR TITLE
use dlerror to retrieve dlopen/dlsym errors

### DIFF
--- a/app.c
+++ b/app.c
@@ -9,6 +9,20 @@
 #include "libfoo.h"
 #endif
 
+#ifdef DLOPEN
+static void
+show_dlerror(const char *fn)
+{
+	const char *errstr;
+
+	errstr = dlerror();
+	if (errstr != NULL)
+		warnx("%s: %s", fn, errstr);
+	else
+		warnx("%s: dlerror() returned NULL, huh?", fn);
+}
+
+#endif
 int
 main(int argc, char *argv[])
 {
@@ -19,13 +33,13 @@ main(int argc, char *argv[])
 
 	handle = dlopen("./libfoo.so", RTLD_LAZY);
 	if (handle == NULL) {
-		warnx("dlopen: %s", dlerror());
+		show_dlerror("dlopen");
 		return (1);
 	}
 
 	foo = dlsym(handle, "foo");
 	if (foo == NULL) {
-		warnx("dlsym: %s", dlerror());
+		show_dlerror("dlsym");
 		dlclose(handle);
 		return(1);
 	}

--- a/app.c
+++ b/app.c
@@ -1,3 +1,4 @@
+#include <err.h>
 #include <stdio.h>
 
 #ifdef DLOPEN
@@ -18,13 +19,13 @@ main(int argc, char *argv[])
 
 	handle = dlopen("./libfoo.so", RTLD_LAZY);
 	if (handle == NULL) {
-		perror("dlopen");
+		warnx("dlopen: %s", dlerror());
 		return (1);
 	}
 
 	foo = dlsym(handle, "foo");
 	if (foo == NULL) {
-		perror("dlsym");
+		warnx("dlsym: %s", dlerror());
 		dlclose(handle);
 		return(1);
 	}


### PR DESCRIPTION
dl*() functions provide error information via dlerror(), not errno.